### PR TITLE
format bibtex + add fix syntax error in wang2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Please open new threads or address all questions to xiyue.wang.scu@gmail.com
 
 ### Citation
 Please use below to cite this paper if you find our work useful in your research.
-```
+```bibtex
 @inproceedings{wang2021transpath,
   title={TransPath: Transformer-Based Self-supervised Learning for Histopathological Image Classification},
   author={Wang, Xiyue and Yang, Sen and Zhang, Jun and Wang, Minghui and Zhang, Jing and Huang, Junzhou and Yang, Wei and Han, Xiao},
@@ -122,8 +122,8 @@ Please use below to cite this paper if you find our work useful in your research
 }
 ``` 
 
-```
-@{wang2022,
+```bibtex
+@misc{wang2022,
   title={Transformer-based Unsupervised Contrastive Learning for Histopathological Image Classification},
   author={Wang, Xiyue and Yang, Sen and Zhang, Jun and Wang, Minghui and Zhang, Jing  and Yang, Wei and Huang, Junzhou  and Han, Xiao},
 }


### PR DESCRIPTION
The wang2022 citation was missing an `@` name. `@misc` was added. In addition, `bibtex` formatting is applied to the citations.